### PR TITLE
Fix wrong Newtonsoft.Json reference in Microphone.Etcd

### DIFF
--- a/Microphone.Etcd/Microphone.Etcd.csproj
+++ b/Microphone.Etcd/Microphone.Etcd.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Microphone.Etcd/packages.config
+++ b/Microphone.Etcd/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Microphone.Etcd references Newtonsoft.Json 6.0.8 while core references v7.0.1, this just fixes that ref up to match core