### PR TITLE
Added overloads for GetLocalIPAddress, and changed RegisterService to optionally allow using them.

### DIFF
--- a/src/Microphone.Core/Cluster.cs
+++ b/src/Microphone.Core/Cluster.cs
@@ -12,7 +12,7 @@ namespace Microphone
             string serviceName, string version, ILogger log)
         {
             var port = uri.Port;
-            var host = DnsUtils.GetLocalIPAddress();
+            var host = DnsUtils.GetLocalIPAddress(uri);
             var publicUri = new Uri($"{uri.Scheme}://{host}:{port}",UriKind.Absolute);
                  
             log.LogInformation("Bootstrapping Microphone");

--- a/src/Microphone.Core/Cluster.cs
+++ b/src/Microphone.Core/Cluster.cs
@@ -9,10 +9,11 @@ namespace Microphone
         public static IClusterClient Client { get; private set; }
 
         public static void RegisterService(Uri uri, IClusterProvider clusterProvider,
-            string serviceName, string version, ILogger log)
+            string serviceName, string version, ILogger log, bool useUriHost = false)
         {
             var port = uri.Port;
-            var host = DnsUtils.GetLocalIPAddress(uri);
+            var host = useUriHost ? DnsUtils.GetLocalIPAddress(uri) 
+                                  : DnsUtils.GetLocalIPAddress();
             var publicUri = new Uri($"{uri.Scheme}://{host}:{port}",UriKind.Absolute);
                  
             log.LogInformation("Bootstrapping Microphone");

--- a/src/Microphone.Core/Util/DnsUtils.cs
+++ b/src/Microphone.Core/Util/DnsUtils.cs
@@ -7,8 +7,14 @@ namespace Microphone.Core.Util
     public class DnsUtils
     {
         public static string GetLocalIPAddress()
+            => GetLocalIPAddress(Dns.GetHostName());
+
+        public static string GetLocalIPAddress(Uri uri)
+            => GetLocalIPAddress(uri.Host);
+
+        public static string GetLocalIPAddress(string hostName)
         {
-            var host = Dns.GetHostEntryAsync(Dns.GetHostName()).Result;
+            var host = Dns.GetHostEntryAsync(hostName).Result;
             foreach (var ip in host.AddressList)
             {
                 if (ip.AddressFamily == AddressFamily.InterNetwork)


### PR DESCRIPTION
This way, RegisterService will create a service from the hostname of the URI provided to it, instead of using the scheme and port, but taking the default local IP address.