### PR TITLE
Added serviceUri parameter to UseMicrophone.

### DIFF
--- a/src/Microphone.Nancy/TinyIoCContainerExtensions.cs
+++ b/src/Microphone.Nancy/TinyIoCContainerExtensions.cs
@@ -9,7 +9,7 @@ namespace Microphone.Nancy
 {
     public static class TinyIoCContainerExtensions
     {
-        public static void RegisterMicrophone<TClusterProvider>(this TinyIoCContainer container,string serviceName,Uri serviceUri) where TClusterProvider: class,IClusterProvider
+        public static void RegisterMicrophone<TClusterProvider>(this TinyIoCContainer container,string serviceName,Uri serviceUri, bool useServiceUriHost = false) where TClusterProvider: class,IClusterProvider
         {
             container.Register<IHealthCheck, EmptyHealthCheck>().AsSingleton();
             container.Register<IClusterProvider, TClusterProvider>().AsSingleton();
@@ -19,7 +19,7 @@ namespace Microphone.Nancy
             var provider = container.Resolve<IClusterProvider>();
             var loggerFactory = container.Resolve<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger("Microphone.Nancy");
-            Cluster.RegisterService(serviceUri,provider,serviceName,"1.0",logger);
+            Cluster.RegisterService(serviceUri,provider,serviceName,"1.0",logger, useServiceUriHost);
         }
     }
 }


### PR DESCRIPTION
Hi @rogeralsing , I initially attempted the UriResolver approach that you recommended in the discussion of Pull Request #37, however I was unable to find a clean way to have the ConsulProvider consume the UriResolver and then use it at the right time - the Uri is defined in Microphone.AspNet's UseMicrophone extension and then passed to a static Cluster function, instead of being something that the ConsulProvider could generate itself, at least not without extensive rework.

See what you think of what I came up with, happy to tailor to any suggestions.