### PR TITLE
Add Attribute Routing in WebAPI Provider

### DIFF
--- a/Microphone.WebApi/WebApiProvider.cs
+++ b/Microphone.WebApi/WebApiProvider.cs
@@ -12,6 +12,10 @@ namespace Microphone.WebApi
             var uri = Configuration.GetUri();
             var config = new HttpSelfHostConfiguration(uri);
 
+            // Attribute routing.
+            config.MapHttpAttributeRoutes();
+
+            // Convention-based routing.
             config.Routes.MapHttpRoute(
                 "API Default", "{controller}/{id}",
                 new { id = RouteParameter.Optional });


### PR DESCRIPTION
Hi folks,

Just picked up Microphone and have been taking it for a spin. Its **exactly** what I was looking for, great stuff!

Just a quick mod, I needed to be able to create custom routes for my WebAPI implementation, seeing as its a one liner and has no ill effect I thought I'd throw it to you.

As far as I'm aware, as long as `config.MapHttpAttributeRoutes();` is called prior to the fixed routing everything else remains functional.

Cheers

Toby
